### PR TITLE
Disable vp9 for libvpx1

### DIFF
--- a/support_packages/libvpx1/package.yml
+++ b/support_packages/libvpx1/package.yml
@@ -14,9 +14,9 @@ builddeps  :
 setup      : |
     %patch -p1 < $pkgfiles/gcc-5.patch
     if [[ ! -z "${EMUL32BUILD}" ]]; then
-        ./configure --prefix=/usr --libdir=%libdir% --disable-static --enable-shared --target=x86-linux-gcc
+        ./configure --prefix=/usr --libdir=%libdir% --disable-static --enable-shared --target=x86-linux-gcc --disable-vp9
     else
-        ./configure --prefix=/usr --libdir=%libdir% --disable-static --enable-shared --target=x86_64-linux-gcc
+        ./configure --prefix=/usr --libdir=%libdir% --disable-static --enable-shared --target=x86_64-linux-gcc --disable-vp9
     fi
 build      : |
     %make


### PR DESCRIPTION
Steam runtime has libvpx 1.0 which is prior to its inclusion, so remains compatible